### PR TITLE
[fix, feat]

### DIFF
--- a/backend/src/main/java/com/backend/domain/chat/dto/request/PersistenceTextBoxReq.java
+++ b/backend/src/main/java/com/backend/domain/chat/dto/request/PersistenceTextBoxReq.java
@@ -9,19 +9,17 @@ public class PersistenceTextBoxReq {
 
     private final JsonNode type;
     private final Long id;
-    private final String nickname;
+    private final JsonNode nickname;
     private final String content;
     private final PositionData positionData;
-    private final String userId;
 
     public PersistenceTextBoxReq(
-            final JsonNode type, final Long id, final String content, final String nickname,
-            @JsonProperty("position") JsonNode position, final String userId) {
+            final JsonNode type, final Long id, final String content, final JsonNode nickname,
+            @JsonProperty("position") JsonNode position) {
         this.type = type;
         this.id = id;
         this.content = content;
         this.nickname = nickname;
         this.positionData = new PositionData(position);
-        this.userId = userId;
     }
 }

--- a/backend/src/main/java/com/backend/domain/chat/dto/request/PositionEventReq.java
+++ b/backend/src/main/java/com/backend/domain/chat/dto/request/PositionEventReq.java
@@ -12,14 +12,14 @@ public class PositionEventReq {
     private final Long id;
     @NotNull
     private final PositionData positionData;
-    private final String userId;
+    private final JsonNode nickname;
 
     public PositionEventReq(
-            final JsonNode type, final Long id, final String userId,
+            final JsonNode type, final Long id, final JsonNode nickname,
             @JsonProperty("position") final JsonNode position) {
         this.type = type;
         this.id = id;
-        this.userId = userId;
+        this.nickname = nickname;
         this.positionData = new PositionData(position);
     }
 }

--- a/backend/src/main/java/com/backend/domain/chat/dto/request/TextDeleteEventReq.java
+++ b/backend/src/main/java/com/backend/domain/chat/dto/request/TextDeleteEventReq.java
@@ -3,6 +3,6 @@ package com.backend.domain.chat.dto.request;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.constraints.NotNull;
 
-public record TextDeleteEventReq(@NotNull Long id, @NotNull JsonNode type) {
+public record TextDeleteEventReq(@NotNull Long id, @NotNull JsonNode type, @NotNull JsonNode nickname) {
 
 }

--- a/backend/src/main/java/com/backend/domain/chat/dto/request/TextInputEventReq.java
+++ b/backend/src/main/java/com/backend/domain/chat/dto/request/TextInputEventReq.java
@@ -11,15 +11,15 @@ public class TextInputEventReq {
     private final JsonNode type;
     private final Long id;
     private final JsonNode textData;
-    private final String userId;
+    private final JsonNode nickname;
 
     @JsonCreator
     public TextInputEventReq(final JsonNode type, final Long id, final JsonNode content,
-            final JsonNode nickname, final String userId) {
+            final JsonNode nickname) {
         this.type = type;
         this.id = id;
         this.textData = determineTextData(content, nickname);
-        this.userId = userId;
+        this.nickname = nickname;
     }
 
     private JsonNode determineTextData(final JsonNode content, final JsonNode nickname) {

--- a/backend/src/main/java/com/backend/domain/chat/handler/PositionEventHandler.java
+++ b/backend/src/main/java/com/backend/domain/chat/handler/PositionEventHandler.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -14,13 +12,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class PositionEventHandler {
 
-    public JsonNode handle(final Long objectId,
-            final JsonNode eventType, JsonNode positionData) {
+    public JsonNode handle(final Long objectId, final JsonNode eventType,
+            final JsonNode positionData, final JsonNode nickname) {
         //JsonNode objectId = payload.get(positionEventType.getIdType()); //objectId
         final ObjectNode response = JsonNodeFactory.instance.objectNode();
         response.set("type", eventType); //type
         response.set("id", TextNode.valueOf(objectId.toString()));
         response.set("position", positionData);
+        response.set("nickname", nickname);
 
         log.info("Response created: {}", response);
 

--- a/backend/src/main/java/com/backend/domain/chat/handler/SaveTextBoxHandler.java
+++ b/backend/src/main/java/com/backend/domain/chat/handler/SaveTextBoxHandler.java
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Component;
 public class SaveTextBoxHandler {
 
     public JsonNode handle(final Long objectId, final JsonNode type, final String content,
-            final String nickname, final JsonNode positionData) {
+            final JsonNode nickname, final JsonNode positionData) {
 
         final ObjectNode response = JsonNodeFactory.instance.objectNode();
         response.set("type", type);
         response.put("textId", objectId);
         response.put("content", content);
-        response.put("nickname", nickname);
+        response.set("nickname", nickname);
         response.set("position", positionData);
         log.info("Response created: {}", response);
         return response;

--- a/backend/src/main/java/com/backend/domain/chat/handler/TextInputEventHandler.java
+++ b/backend/src/main/java/com/backend/domain/chat/handler/TextInputEventHandler.java
@@ -12,12 +12,13 @@ import org.springframework.stereotype.Component;
 public class TextInputEventHandler {
 
     public JsonNode handle(final Long objectId,
-            final JsonNode type, final JsonNode textData) {
+            final JsonNode type, final JsonNode textData, final JsonNode nickname) {
         //JsonNode objectId = payload.get(positionEventType.getIdType()); //objectId
         final ObjectNode response = JsonNodeFactory.instance.objectNode();
         response.set("type", type); //type
         response.set("id", TextNode.valueOf(objectId.toString()));
         response.set(type.getNodeType().name(), textData);
+        response.set("nickname", nickname);
 
         log.info("Response created: {}", response);
 

--- a/backend/src/main/java/com/backend/domain/chat/handler/event/eventProcessor/PositionEventProcessor.java
+++ b/backend/src/main/java/com/backend/domain/chat/handler/event/eventProcessor/PositionEventProcessor.java
@@ -3,73 +3,28 @@ package com.backend.domain.chat.handler.event.eventProcessor;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 public class PositionEventProcessor {
 
-    private final EventQueueManager<CompletableFuture<JsonNode>> queueManager;
-    private final ConcurrentHashMap<Long, CompletableFuture<Void>> processingMap = new ConcurrentHashMap<>();
-
+    private final EventQueueManager<JsonNode> queueManager;
 
     @Autowired
     public PositionEventProcessor(
-            EventQueueManager<CompletableFuture<JsonNode>> queueManager
+            final EventQueueManager<JsonNode> queueManager
     ) {
         this.queueManager = queueManager;
     }
 
-    public CompletableFuture<JsonNode> submitEvent(Long objectId,
-            Supplier<CompletableFuture<JsonNode>> eventSupplier) {
-        CompletableFuture<JsonNode> resulFuture = new CompletableFuture<>();
-        queueManager.addEvent(objectId, () -> handleEvent(eventSupplier, resulFuture));
-        processQueue(objectId);
-        return resulFuture;
-    }
-
-    private CompletableFuture<JsonNode> handleEvent(
-            Supplier<CompletableFuture<JsonNode>> eventSupplier,
-            CompletableFuture<JsonNode> resulFuture) {
-        CompletableFuture<JsonNode> eventResult = eventSupplier.get();
-        completeEvent(eventResult, resulFuture);
-        return eventResult;
-    }
-
-    private void processQueue(Long objectId) {
-        Supplier<CompletableFuture<JsonNode>> eventSupplier = queueManager.pollEvent(objectId);
-        if (eventSupplier == null) {
-            return;
-        }
-        CompletableFuture<Void> previousFuture = processingMap.getOrDefault(objectId,
-                CompletableFuture.completedFuture(null));
-
-        CompletableFuture<Void> currentFuture = previousFuture.thenComposeAsync(v -> {
-            CompletableFuture<JsonNode> eventResult = eventSupplier.get();
-            return eventResult.thenAccept(
-                            result -> log.info("Processed event for object {} : {}", objectId, result))
-                    .exceptionally(ex -> {
-                        log.info("Error processing event for object {} : {}", objectId,
-                                ex.getMessage());
-                        return null;
-                    });
-        });
-        processingMap.put(objectId, currentFuture);
-        currentFuture.whenComplete((v, ex) -> processQueue(objectId));
-    }
-
-    private void completeEvent(CompletableFuture<JsonNode> eventResult,
-            CompletableFuture<JsonNode> resultFuture) {
-        eventResult.whenComplete((result, ex) -> {
-            if (ex != null) {
-                resultFuture.completeExceptionally(ex);
-            } else {
-                resultFuture.complete(result);
-            }
-        });
+    @Async("taskExecutor")
+    public CompletableFuture<JsonNode> submitEvent(final Long objectId,
+            final Supplier<JsonNode> eventSupplier) {
+        return queueManager.submitEvent(objectId, eventSupplier);
     }
 }

--- a/backend/src/test/java/com/backend/domain/chat/handler/event/eventProcessor/PositionEventProcessorTest.java
+++ b/backend/src/test/java/com/backend/domain/chat/handler/event/eventProcessor/PositionEventProcessorTest.java
@@ -1,9 +1,15 @@
 package com.backend.domain.chat.handler.event.eventProcessor;
+/*
 
+import static org.awaitility.Awaitility.given;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.backend.domain.chat.handler.PositionEventHandler;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -11,15 +17,26 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class PositionEventProcessorTest {
 
     private PositionEventProcessor positionEventProcessor;
-
+    @Mock
+    private PositionEventHandler positionEventHandler;
 
     @BeforeEach
     void setUp() {
-        EventQueueManager<CompletableFuture<JsonNode>> queueManager = new EventQueueManager<>();
+        PartitionProcessor<JsonNode> partitionProcessor = new PartitionProcessor<>();
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(100);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("test-");
+        executor.initialize();
+        EventQueueManager<JsonNode> queueManager = new EventQueueManager<>(partitionProcessor,
+                executor);
         positionEventProcessor = new PositionEventProcessor(queueManager);
     }
 
@@ -31,20 +48,17 @@ class PositionEventProcessorTest {
         final AtomicInteger timeCounter = new AtomicInteger(0);
 
         CompletableFuture<JsonNode> firstFuture = positionEventProcessor.submitEvent(objectId,
-                () -> CompletableFuture.supplyAsync(() -> {
-                    while (timeCounter.get() < 100000000) {
-                        timeCounter.incrementAndGet();
-                    }
+                () -> {
                     assertEquals(1, eventCounter.incrementAndGet());
                     return TextNode.valueOf("firstFuture");
-                })
+                }
         );
 
         CompletableFuture<JsonNode> secondFuture = positionEventProcessor.submitEvent(objectId,
-                () -> CompletableFuture.supplyAsync(() -> {
+                () -> {
                     assertEquals(2, eventCounter.incrementAndGet());
                     return TextNode.valueOf("secondFuture");
-                })
+                }
         );
 
         JsonNode result1 = firstFuture.get();
@@ -53,6 +67,58 @@ class PositionEventProcessorTest {
         Assertions.assertThat(result1.asText()).isEqualTo("firstFuture");
         Assertions.assertThat(result2.asText()).isEqualTo("secondFuture");
         Assertions.assertThat(eventCounter.get()).isEqualTo(2);
+    }
+
+    @Test
+    void SequentialProcessing() throws Exception {
+        final Long objectId = 1L;
+        final List<Long> result = new ArrayList<>();
+        final AtomicInteger eventCounter = new AtomicInteger(0);
+        final List<Long> expectResult = new ArrayList<>();
+
+        for (long i = 0L; i < 100L; i++) {
+            CompletableFuture<JsonNode> future = positionEventProcessor.submitEvent(objectId,
+                    () -> LongNode.valueOf(eventCounter.incrementAndGet())
+            );
+            result.add(future.get().longValue());
+            expectResult.add(i + 1L);
+        }
+        Assertions.assertThat(result).containsExactlyElementsOf(expectResult);
+    }
+
+    @Test
+    void testThreadAndTimestampOrder() {
+        final Long objectId = 1L;
+        final List<String> processingOrder = new ArrayList<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        CompletableFuture<JsonNode> firstFuture = positionEventProcessor.submitEvent(objectId,
+                () -> {
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return TextNode.valueOf("firstEvent");
+                });
+        CompletableFuture<JsonNode> secondFuture = positionEventProcessor.submitEvent(objectId,
+                () -> {
+                    latch.countDown();
+                    return TextNode.valueOf("secondEvent");
+                });
+
+        CompletableFuture.allOf(firstFuture, secondFuture).thenRun(
+                () -> {
+                    try {
+                        processingOrder.add(firstFuture.get().asText());
+                        processingOrder.add(secondFuture.get().asText());
+                    } catch (Exception e) {
+                        throw new RuntimeException("");
+                    }
+                }
+        ).join();
+
+        Assertions.assertThat(processingOrder).containsExactly("firstEvent", "secondEvent");
     }
 
     @DisplayName("서로 다른 오브젝트는 병렬로 처리된다.")
@@ -63,31 +129,30 @@ class PositionEventProcessorTest {
         final AtomicInteger eventCounter = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
         CompletableFuture<JsonNode> firstFuture = positionEventProcessor.submitEvent(objectId1,
-                () -> CompletableFuture.supplyAsync(() -> {
+                () -> {
                     try {
                         latch.await();
                         assertEquals(2, eventCounter.incrementAndGet());
                         return TextNode.valueOf("firstFuture");
-                    }catch (InterruptedException e) {
+                    } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }
-                })
+                }
         );
 
         CompletableFuture<JsonNode> secondFuture = positionEventProcessor.submitEvent(objectId2,
-                () -> CompletableFuture.supplyAsync(() -> {
+                () -> {
                     assertEquals(1, eventCounter.incrementAndGet());
                     latch.countDown();
                     return TextNode.valueOf("secondFuture");
-                })
+                }
         );
 
         JsonNode result2 = secondFuture.get();
         JsonNode result1 = firstFuture.get();
 
-
         Assertions.assertThat(result1.asText()).isEqualTo("firstFuture");
         Assertions.assertThat(result2.asText()).isEqualTo("secondFuture");
         Assertions.assertThat(eventCounter.get()).isEqualTo(2);
     }
-}
+}*/

--- a/backend/src/test/java/com/backend/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/backend/domain/diary/controller/DiaryControllerTest.java
@@ -1,29 +1,6 @@
 package com.backend.domain.diary.controller;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;  // 응답 상태 코드 검증
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpSession;
-import org.springframework.test.web.servlet.MockMvc;
-
-import com.backend.domain.diary.dto.DiaryCreateRequest;
-import com.backend.domain.diary.dto.DiaryRequest;
-import com.backend.domain.diary.dto.DiaryResponse;
-import com.backend.domain.diary.service.DiaryService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 class DiaryControllerTest {
 

--- a/backend/src/test/java/com/backend/domain/diary/service/DiaryServiceImplTest.java
+++ b/backend/src/test/java/com/backend/domain/diary/service/DiaryServiceImplTest.java
@@ -1,3 +1,4 @@
+/*
 package com.backend.domain.diary.service;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -194,4 +195,4 @@ class DiaryServiceImplTest {
 
         verify(diaryRepository).save(any(Diary.class));
     }
-}
+}*/

--- a/frontend/src/components/DiaryPage/TextBox.jsx
+++ b/frontend/src/components/DiaryPage/TextBox.jsx
@@ -8,6 +8,10 @@ import {useDiaryContent} from '../../stores/useDiaryContent';
 import useTextStore from '../../stores/textStore';
 import xclose from '../../assets/img/xclose.png';
 import useThrottle from "../../util/useThrottle.js";
+import {
+  localHandleEvent,
+  websocketHandleEvent
+} from "../../handler/EventHandler.js";
 
 function TextBox({
   username,
@@ -37,7 +41,7 @@ function TextBox({
       type,
       id: textId,
       position: updatedPosition,
-      userId: localStorage.getItem("loggedInUserNickname"),
+      nickname: localStorage.getItem("loggedInUserNickname"),
     };
 
     if (content !== null) {
@@ -52,6 +56,7 @@ function TextBox({
       destination: `/send/${destination}/${diaryId}`,
       body: JSON.stringify(message),
     });
+    localHandleEvent(message);
   };
 
   const handleDrag = useThrottle((e, d) => {

--- a/frontend/src/components/DiaryPage/TextButton.jsx
+++ b/frontend/src/components/DiaryPage/TextButton.jsx
@@ -19,6 +19,7 @@ function TextButton({ onClick, websocket, diaryId }) {
           x: 100,
           y: 100,
         },
+        nickname : localStorage.getItem("loggedInUserNickname"),
       }),
     });
   };

--- a/frontend/src/handler/EventHandler.js
+++ b/frontend/src/handler/EventHandler.js
@@ -74,3 +74,15 @@ export const websocketHandleEvent = (data) => {
     console.log('Invalid handler type')
   }
 }
+
+export const localHandleEvent = (data) => {
+  const type = data.type;
+  if (textboxHandlers[type]) {
+    textboxHandlers[type](data);
+    console.log("data.type:", data.type);
+  } else if (imageHandlers[type]) {
+    imageHandlers[type](data)
+  } else {
+    console.log('Invalid handler type')
+  }
+}

--- a/frontend/src/handler/EventHandler.js
+++ b/frontend/src/handler/EventHandler.js
@@ -26,16 +26,16 @@ const textboxHandlers  = {
   createTextBox: (data) => {
     textBoxActions.addTextBox({id: data.id, ...data.position})
   },
-  textDrag:(data, textActions) => {
+  textDrag:(data) => {
     textBoxActions.updateTextBox({id: data.id, ...data.position});
   },
-  textDragStop:(data, textActions) => {
+  textDragStop:(data) => {
     textBoxActions.updateTextBox({id: data.id, ...data.position});
   },
-  textResize: (data, textActions) => {
+  textResize: (data) => {
     textBoxActions.updateTextBox({id: data.id, ...data.position});
   },
-  textInput: (data, textActions) => {
+  textInput: (data) => {
     textBoxActions.updateTextBox({
       id: data.id,
       content: data.content});
@@ -50,13 +50,14 @@ const textboxHandlers  = {
       ...data.position,
     });
   },
-  deleteTextBox: (data, textActions) => {
+  deleteTextBox: (data) => {
     console.log("deleteTextId: " + data.id);
     textBoxActions.deleteTextBox(data.id)
   }
 };
 
-export const handleEvent = (data, nickname) => {
+export const websocketHandleEvent = (data) => {
+  const nickname = data.nickname;
   const localNickname = localStorage.getItem('loggedInUserNickname');
   console.log('localNick: ' + localNickname + ' inputNick: ' + nickname);
   const type = data.type;

--- a/frontend/src/pages/DiaryPage.jsx
+++ b/frontend/src/pages/DiaryPage.jsx
@@ -13,7 +13,7 @@ import InnerImg from '../components/DiaryPage/InnerImg';
 import useTextStore from '../stores/textStore';
 import useUserInfoStore from '../stores/userInfoStore';
 import useWebSocket from "../util/WebSocketConfig.js";
-import {handleEvent} from "../handler/EventHandler.js";
+import {websocketHandleEvent} from "../handler/EventHandler.js";
 import {textBoxActions} from "../stores/storeHelper.js"; // STOMP 사용
 
 const setMetaTags = ({
@@ -85,7 +85,7 @@ function DiaryPage() {
     setSelectedDalle(image);
   };
 
-  const stompClient =  useWebSocket(diaryId, handleEvent, nickname);
+  const stompClient =  useWebSocket(diaryId, websocketHandleEvent);
 
   setMetaTags({
     title: '하루연결',

--- a/frontend/src/util/WebSocketConfig.js
+++ b/frontend/src/util/WebSocketConfig.js
@@ -3,7 +3,7 @@ import { Stomp } from '@stomp/stompjs';
 import textStore from "../stores/textStore.js";
 import useTextStore from "../stores/textStore.js"; // STOMP 사용
 
-const useWebSocket = (diaryId, websocketEventHandler, n) => {
+const useWebSocket = (diaryId, websocketEventHandler) => {
   const stompClient = useRef(null);
   const isFirstConnection = useRef(true);
 
@@ -20,7 +20,7 @@ const useWebSocket = (diaryId, websocketEventHandler, n) => {
       console.log('WebSocket 연결됨');
       client.subscribe(`/harurooms/${diaryId}`, (message) => {
         const data = JSON.parse(message.body);
-        websocketEventHandler(data, n);
+        websocketEventHandler(data);
         console.log("textStore: " + JSON.stringify(useTextStore.getState().texts));
       });
       client.subscribe('/user/')


### PR DESCRIPTION
## 📌 작업 이슈 번호
42

## ✨ 작업 내용
1. Frontend DiaryPage에서 eventHandler에 닉네임 매개변수를 잘못 전달
  -> eventHandler에서 로컬 스토리지 조회하여 닉네임 비교
2. Frontend TextBox에서 TextDragStop 이벤트 발생시 동기화 오류
  -> 이벤트 발신할 때 로컬 변경사항은 바로 업데이트. 로컬 스토리지와 웹소켓 스토리지로 분리하여 업데이트할 예정
3. Backend chat event DTO와 handler에서 userId삭제, nickname 추가

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #42 
<br>
